### PR TITLE
Fix Netlify deployment - remove restrictive redirect conditions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -34,7 +34,6 @@
   from = "/*"
   to = "/index.html"
   status = 200
-  conditions = {Role = ["admin"], Country = ["US"]}
 
 # Security redirects
 [[redirects]]


### PR DESCRIPTION
- Remove Role and Country conditions from redirect rule
- This was causing 404 errors for all users
- Site now accessible at vernon-landlords.netlify.app

🤖 Generated with [Claude Code](https://claude.ai/code)